### PR TITLE
И1.С1.Б1.З1.0 Расширение карточки пациента и подготовка данных

### DIFF
--- a/api/src/Entity/Appointment.php
+++ b/api/src/Entity/Appointment.php
@@ -8,11 +8,13 @@ use ApiPlatform\Metadata\ApiResource;
 use Doctrine\ORM\Mapping as ORM;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource]
 #[ORM\Entity]
 #[ORM\Table(name: 'appointments')]
 #[ApiFilter(SearchFilter::class, properties: ['treatment' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['appointmentDt'])]
 class Appointment
 {
     #[ORM\Id]

--- a/api/src/Entity/TestHistory.php
+++ b/api/src/Entity/TestHistory.php
@@ -14,6 +14,7 @@ use App\State\TestHistoryLatestProvider;
 use Doctrine\ORM\Mapping as ORM;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource(
     operations: [
@@ -33,6 +34,7 @@ use ApiPlatform\Metadata\ApiFilter;
 #[ORM\Entity]
 #[ORM\Table(name: 'test_history')]
 #[ApiFilter(SearchFilter::class, properties: ['treatment' => 'exact'])]
+#[ApiFilter(OrderFilter::class, properties: ['creationDt'])]
 class TestHistory
 {
     #[ORM\Id]

--- a/api/src/Entity/Treatment.php
+++ b/api/src/Entity/Treatment.php
@@ -15,6 +15,7 @@ use ApiPlatform\Metadata\Post;
 use App\Filter\ActiveTreatmentFilter;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 
 #[ApiResource(
     operations: [
@@ -40,6 +41,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiFilter(SearchFilter::class, properties: [
     'patient' => 'exact',
 ])]
+#[ApiFilter(OrderFilter::class, properties: ['begDt', 'realEndDt'])]
 class Treatment
 {
     #[ORM\Id]

--- a/frontend/src/components/PatientHistory/PatientHistory.script.js
+++ b/frontend/src/components/PatientHistory/PatientHistory.script.js
@@ -127,14 +127,31 @@ export default {
           snils: patientData.snils || '—',
           hospital: hospitalName || '—',
           diagnosis: treatment?.diagnosis || '—',
+          comorbiditiesRaw: treatment?.comorbidities || '',
           additionalConditions: treatment?.comorbidities
             ? [treatment.comorbidities] 
             : ['Нет данных'],
+          mnoFrom: treatment?.mnoFrom ?? null,
+          mnoTo: treatment?.mnoTo ?? null,
+          drugName: drugName || '—',
+          drugId: treatment?.drug ? extractIdFromIri(treatment.drug) : null,
+          begDt: treatment?.begDt?.toISOString?.() ?? null,
+          planEndDt: treatment?.planEndDt?.toISOString?.() ?? null,
+          treatmentComment: treatment?.comment || '',
+          treatmentIri: treatment?.['@id'] || null,
           consentSigned: false,
           riskScores: null,
           pharmacogenetics: [],
           mutations: [],
           isActive: isActive,
+          realEndDt: treatment?.realEndDt?.toISOString?.() ?? null,
+          stoppingReason: treatment?.stoppingReason || null,
+          hemorrhages: treatment?.hemorrhages ?? 0,
+
+          consentSigned: false,
+          riskScores: null,
+          pharmacogenetics: [],
+          mutations: [],
         };
       } catch (err) {
         console.error('Ошибка загрузки истории:', err);

--- a/frontend/src/components/PatientHistory/PatientHistory.script.js
+++ b/frontend/src/components/PatientHistory/PatientHistory.script.js
@@ -78,7 +78,6 @@ export default {
             }
           });
           appointments = apptResp.data.member || [];
-          appointments.sort((a, b) => new Date(a.appointmentDt) - new Date(b.appointmentDt));
 
           const historyResp = await testHistoryApi.getAll({
             treatment: treatment['@id'],
@@ -86,7 +85,6 @@ export default {
             itemsPerPage: 300
           });
           historyItems = historyResp.member || [];
-          historyItems.sort((a, b) => new Date(b.creationDt) - new Date(a.creationDt));
         }
 
         this.medicalData = historyItems.map(item => {

--- a/frontend/src/components/PatientHistory/PatientHistory.script.js
+++ b/frontend/src/components/PatientHistory/PatientHistory.script.js
@@ -39,14 +39,14 @@ export default {
         const patientData = await patientApi.getOne(this.id);
         const treatmentResp = await treatmentApi.getAll({
           patient: `/api/patients/${this.id}`,
-          active: true,
           itemsPerPage: 1,
           order: { begDt: 'desc' }
         });
         const treatments = treatmentResp.member || [];
         const treatment = treatments.length > 0 ? treatments[0] : null;
 
-        // Загружаем больницу
+        const isActive = treatment ? (treatment.realEndDt === null || treatment.realEndDt === undefined) : false;
+
         let hospitalName = '';
         if (patientData.hospital) {
           const hospitalId = extractIdFromIri(patientData.hospital);
@@ -56,7 +56,6 @@ export default {
           }
         }
 
-        // Загружаем препарат
         let drugName = '';
         if (treatment?.drug) {
           const drugId = extractIdFromIri(treatment.drug);
@@ -68,7 +67,6 @@ export default {
           }
         }
 
-        // Загружаем историю анализов и назначения
         let historyItems = [];
         let appointments = [];
         if (treatment?.['@id']) {
@@ -76,7 +74,7 @@ export default {
             params: {
               treatment: treatment['@id'],
               order: { appointmentDt: 'asc' },
-              itemsPerPage: 1000  // достаточно для полного списка
+              itemsPerPage: 1000
             }
           });
           appointments = apptResp.data.member || [];
@@ -137,7 +135,8 @@ export default {
           consentSigned: false,
           riskScores: null,
           pharmacogenetics: [],
-          mutations: []
+          mutations: [],
+          isActive: isActive,
         };
       } catch (err) {
         console.error('Ошибка загрузки истории:', err);

--- a/frontend/src/components/PatientHistory/PatientHistory.script.js
+++ b/frontend/src/components/PatientHistory/PatientHistory.script.js
@@ -2,7 +2,7 @@ import { patientApi } from '@/api/patients';
 import { treatmentApi } from '@/api/treatments';
 import { drugApi } from '@/api/drug';
 import { extractIdFromIri } from '@/utils/apiHelpers';
-import { calculateAge, formatAge } from '@/utils/formatters';
+import { calculateAge, formatAge, formatDate } from '@/utils/formatters';
 import RiskScale from '@/components/RiskScale/RiskScale.vue';
 import apiClient from '@/api/client';
 import { testHistoryApi } from '@/api/testHistory';
@@ -18,7 +18,9 @@ export default {
       patient: null,
       loading: true,
       error: null,
-      medicalData: []
+      medicalData: [],
+      editingPatient: false,
+      editingTreatment: false,
     }
   },
   watch: {
@@ -114,10 +116,11 @@ export default {
         const age = calculateAge(patientData.birthday);
 
         this.patient = {
+          // персональные данные
           name: fullName,
           age: age ? formatAge(age) : '—',
           birthDate: patientData.birthday
-            ? new Date(patientData.birthday).toLocaleDateString('ru-RU')
+            ? formatDate(patientData.birthday)
             : '—',
           address: patientData.address || '—',
           phone: patientData.smsPhone || '—',
@@ -126,25 +129,23 @@ export default {
           insurance: patientData.healthInsurance || '—',
           snils: patientData.snils || '—',
           hospital: hospitalName || '—',
+
+          // лечение
           diagnosis: treatment?.diagnosis || '—',
           comorbiditiesRaw: treatment?.comorbidities || '',
           additionalConditions: treatment?.comorbidities
-            ? [treatment.comorbidities] 
+            ? [treatment.comorbidities]
             : ['Нет данных'],
           mnoFrom: treatment?.mnoFrom ?? null,
           mnoTo: treatment?.mnoTo ?? null,
           drugName: drugName || '—',
           drugId: treatment?.drug ? extractIdFromIri(treatment.drug) : null,
-          begDt: treatment?.begDt?.toISOString?.() ?? null,
-          planEndDt: treatment?.planEndDt?.toISOString?.() ?? null,
+          begDt: treatment?.begDt ? formatDate(treatment.begDt) : null,
+          planEndDt: treatment?.planEndDt ? formatDate(treatment.planEndDt) : null,
           treatmentComment: treatment?.comment || '',
           treatmentIri: treatment?.['@id'] || null,
-          consentSigned: false,
-          riskScores: null,
-          pharmacogenetics: [],
-          mutations: [],
           isActive: isActive,
-          realEndDt: treatment?.realEndDt?.toISOString?.() ?? null,
+          realEndDt: treatment?.realEndDt ? formatDate(treatment.realEndDt) : null,
           stoppingReason: treatment?.stoppingReason || null,
           hemorrhages: treatment?.hemorrhages ?? 0,
 

--- a/frontend/src/components/PatientHistory/PatientHistory.style.css
+++ b/frontend/src/components/PatientHistory/PatientHistory.style.css
@@ -62,13 +62,52 @@
 .info-group label {
   font-weight: 600;
   color: #2c3e50;
-  min-width: 100px;
-  flex-shrink: 0;
+  flex: 1 1 40%;
+  min-width: 0;
+  word-break: break-word;
+  overflow-wrap: break-word;
 }
 
 .info-group span {
-  flex: 1;
+  flex: 1 1 60%;
   word-break: break-word;
+  overflow-wrap: break-word;
+  min-width: 0;
+}
+
+.treatment-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.status-active {
+  color: #27ae60;
+  font-weight: 600;
+}
+
+.status-inactive {
+  color: #7f8c8d;
+  font-weight: 600;
+}
+
+.btn-edit-treatment {
+  background: transparent;
+  border: 1px solid #3498db;
+  color: #3498db;
+  font-size: 18px;
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-edit-treatment:hover {
+  background: #3498db;
+  color: white;
 }
 
 /* КОМПОНЕНТ СОГЛАСИЯ */
@@ -248,7 +287,24 @@
 }
 
 /* АДАПТИВНОСТЬ ДЛЯ МОБИЛЬНЫХ УСТРОЙСТВ */
+
+@media (max-width: 1200px) {
+  .patient-main-content {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 768px) {
+  .info-group {
+    flex-direction: column;
+    gap: 4px;
+  }
+  .info-group label {
+    flex: auto;
+  }
+  .info-group span {
+    flex: auto;
+  }
   .patient-main-content {
     grid-template-columns: 1fr;
     gap: 15px;

--- a/frontend/src/components/PatientHistory/PatientHistory.template.html
+++ b/frontend/src/components/PatientHistory/PatientHistory.template.html
@@ -86,9 +86,81 @@
             </div>
 
             <div class="section">
-                <h3>Диагноз</h3>
+                <div class="treatment-section-header">
+                    <h3>Лечение</h3>
+                    <button 
+                        v-if="patient.isActive"
+                        class="btn-edit-treatment"
+                        title="Редактировать лечение"
+                    >✎</button>
+                </div>
                 <div class="section-content">
-                    <p>{{ patient.diagnosis }}</p>
+                    <div class="info-row">
+                        <div class="info-group">
+                            <label>Диагноз:</label>
+                            <span>{{ patient.diagnosis }}</span>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-group">
+                            <label>Осложнения:</label>
+                            <span>{{ patient.comorbiditiesRaw || '—' }}</span>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-group">
+                            <label>Целевой диапазон МНО:</label>
+                            <span>{{ patient.mnoFrom }} – {{ patient.mnoTo }}</span>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-group">
+                            <label>Препарат:</label>
+                            <span>{{ patient.drugName }}</span>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-group">
+                            <label>Дата начала:</label>
+                            <span>{{ patient.begDt }}</span>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-group">
+                            <label>Плановая дата окончания:</label>
+                            <span>{{ patient.planEndDt || '—' }}</span>
+                        </div>
+                    </div>
+
+                    <template v-if="!patient.isActive">
+                        <div class="info-row">
+                            <div class="info-group">
+                                <label>Дата завершения:</label>
+                                <span>{{ patient.realEndDt || '—' }}</span>
+                            </div>
+                        </div>
+                        <div class="info-row">
+                            <div class="info-group">
+                                <label>Причина завершения:</label>
+                                <span>{{ patient.stoppingReason || '—' }}</span>
+                            </div>
+                        </div>
+                    </template> 
+                    
+                    <div class="info-row">
+                        <div class="info-group">
+                            <label>Статус:</label>
+                            <span :class="patient.isActive ? 'status-active' : 'status-inactive'">
+                                {{ patient.isActive ? 'Активно' : 'Завершено' }}
+                            </span>
+                        </div>
+                    </div>
+                    <div class="info-row">
+                        <div class="info-group">
+                            <label>Кровотечения:</label>
+                            <span>{{ patient.hemorrhages ? 'есть' : 'нет' }}</span>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/frontend/src/components/PatientHistory/PatientHistory.template.html
+++ b/frontend/src/components/PatientHistory/PatientHistory.template.html
@@ -68,7 +68,7 @@
                     </div>
                 </div>
 
-                <div class="consent-row">
+                <div v-if="false" class="consent-row">
                     <div class="consent-text">Информированное согласие на обработку данных и мониторинг</div>
                     <div class="status-container">
                         <span class="status-text">{{ patient.consentSigned ? 'Подписано' : 'Не подписано' }}</span>
@@ -84,7 +84,9 @@
                     </div>
                 </div>
             </div>
+        </div>
 
+        <div class="right-column">
             <div class="section">
                 <div class="treatment-section-header">
                     <h3>Лечение</h3>
@@ -174,17 +176,14 @@
                     </ul>
                 </div>
             </div>
-        </div>
-
-        <div class="right-column">
-            <div class="section risk-scale-section">
+            <div v-if="false" class="section risk-scale-section">
                 <RiskScale v-if="patient.riskScores" :risk-scores="patient.riskScores" />
                 <div v-else class="section-content">
                     <p>Нет данных о рисках</p>
                 </div>
             </div>
 
-            <div class="section">
+            <div v-if="false" class="section">
                 <h3>Фармакогенетика</h3>
                 <div class="section-content pharmacogenetics-content">
                     <template v-if="patient.pharmacogenetics && patient.pharmacogenetics.length">
@@ -198,7 +197,7 @@
                 </div>
             </div>
 
-            <div class="section">
+            <div v-if="false" class="section">
                 <h3>Мутации/Полиморфизмы</h3>
                 <div class="section-content mutations-content">
                     <template v-if="patient.mutations && patient.mutations.length">


### PR DESCRIPTION
Спринт 1: Завершение карточки врача
Блок 1. Редактирование лечения и пациента
Задача 1.0. Расширение карточки пациента и подготовка данных

Цель: Дополнить карточку пациента в PatientHistory всеми полями из сущностей Treatment и Patient, необходимыми для полноценного отображения и последующего inline-редактирования. Учесть особенности завершённых лечений и унаследованные данные.

Исходное состояние:
    • Компонент PatientHistory загружает только активное лечение (через active: true) и отображает ограниченный набор полей.
    • Поля comorbidities уже отображаются как additionalConditions в виде списка из одного строкового элемента.
    • Завершённые лечения не загружаются, поля real_end_dt и stopping_reason в интерфейсе отсутствуют.
    • Унаследованное поле hemorrhages (битовая маска) присутствует в БД, но не отображается.
Требуется:
    1. Расширение загрузки данных о лечении
        ◦ В методе loadPatientData загружать последнее лечение без фильтра active.
        ◦ Определить признак активности лечения: если real_end_dt === null — лечение активно, иначе — завершено.
        ◦ Расширить объект this.patient следующими полями:
            ▪ comorbidities — строка (уже загружается, но убедиться, что сохраняется как сырая строка для редактирования);
            ▪ mnoFrom — число (нижняя граница МНО);
            ▪ mnoTo — число (верхняя граница МНО);
            ▪ drugName — строка (наименование препарата);
            ▪ drugId — число (ID препарата, извлечённый из IRI);
            ▪ begDt — строка (дата начала);
            ▪ planEndDt — строка или null (плановая дата окончания);
            ▪ treatmentComment — строка (комментарий к лечению);
            ▪ treatmentIri — строка (IRI для PATCH-запросов);
            ▪ isActive — булево (true, если real_end_dt === null);
            ▪ realEndDt — строка или null (фактическая дата завершения);
            ▪ stoppingReason — строка или null (причина завершения);
            ▪ hemorrhages — число (код битовой маски, «как есть»).
    2. Доработка шаблона (только чтение)
        ◦ В секции «Лечение» отобразить все перечисленные выше поля в режиме чтения.
        ◦ Для активного лечения: real_end_dt и stopping_reason не отображаются.
        ◦ Для завершённого лечения: real_end_dt и stopping_reason отображаются, кнопка редактирования не показывается.
        ◦ Поле hemorrhages отображается как «Кровотечения: есть» (или «нет», если 0). Это поле не редактируется ни в каком режиме.
        ◦ Секция «Осложнения» продолжает работать как раньше: additionalConditions формируется из comorbidities как массив из одного строкового элемента (или ['Нет данных'] при пустой строке).
    3. Флаги режимов редактирования
        ◦ В data компонента PatientHistory добавить:
            ▪ editingPatient: false
            ▪ editingTreatment: false
    4. Прочие виджеты
        ◦ Блоки Информированное согласие, «Фармакогенетика», «Мутации/Полиморфизмы» и riskScores скрыть. Их реализация запланирована на И2.
Ожидаемый результат: В карточке пациента отображается полная информация о лечении (включая статус активности, даты, причину завершения для закрытых курсов, код геморрагических событий). Система готова к переключению в режим редактирования для активного лечения. Кнопка редактирования для завершённого лечения скрыта.