### PR TITLE
1.3 FUNC-008 Inline-редактирование персональных данных пациента

### DIFF
--- a/frontend/src/api/patients.js
+++ b/frontend/src/api/patients.js
@@ -22,4 +22,7 @@ export const patientApi = {
     create(data) {
         return apiClient.post('/patients', data).then(res => res.data);
     },
+    update(id, data) {
+        return apiClient.patch(`/patients/${id}`, data).then(res => res.data);
+    },
 }

--- a/frontend/src/components/PatientHistory/PatientHistory.script.js
+++ b/frontend/src/components/PatientHistory/PatientHistory.script.js
@@ -2,7 +2,7 @@ import { patientApi } from '@/api/patients';
 import { treatmentApi } from '@/api/treatments';
 import { drugApi } from '@/api/drug';
 import { extractIdFromIri } from '@/utils/apiHelpers';
-import { calculateAge, formatAge, formatDate } from '@/utils/formatters';
+import { calculateAge, formatAge, formatDate, formatPhone, formatPassport, formatSnils } from '@/utils/formatters';
 import RiskScale from '@/components/RiskScale/RiskScale.vue';
 import apiClient from '@/api/client';
 import { testHistoryApi } from '@/api/testHistory';
@@ -12,6 +12,7 @@ import { useAppointmentAddStore } from '@/stores/appointmentAddStore';
 import AppointmentAdd from '@/components/PatientHistory/AppointmentAdd/AppointmentAdd.vue';
 import TestAddModal from '@/components/PatientHistory/TestAddModal/TestAddModal.vue';
 import MnoChart from '@/components/PatientHistory/MnoChart/MnoChart.vue';
+import { isValidPhone, isValidSnils, isValidPassport } from '@/utils/validators';
 
 export default {
     name: 'PatientHistory',
@@ -21,18 +22,22 @@ export default {
     },
     data() {
         return {
-          patient: null,
-          loading: true,
-          error: null,
-          medicalData: [],
-          editingPatient: false,
-          editingTreatment: false,
-          originalTreatmentJson: '',
-          editingTreatmentData: {},
-          allDrugs: [],
-          treatmentFormError: '',
-          showTestModal: false,
-          showAppointmentInlineModal: false,
+            patient: null,
+            loading: true,
+            error: null,
+            medicalData: [],
+            editingPatient: false,
+            editingTreatment: false,
+            originalTreatmentJson: '',
+            editingTreatmentData: {},
+            allDrugs: [],
+            treatmentFormError: '',
+            showTestModal: false,
+            showAppointmentInlineModal: false,
+            editingPatient: false,
+            originalPatientJson: '',  
+            editingPatientData: {},
+            patientFormError: '',
         }
     },
     watch: {
@@ -399,6 +404,116 @@ export default {
         onAppointmentInlineSaved() {
             this.loadPatientData();
             this.showAppointmentInlineModal = false;
+        },
+
+        startEditingPatient() {
+            this.patientFormError = '';
+            this.editingPatientData = {
+                address: this.patient.address || '',
+                phone: formatPhone(this.patient.phone) || this.patient.phone || '',
+                passport: formatPassport(this.patient.passport) || this.patient.passport || '',
+                insurance: this.patient.insurance || '',
+                snils: formatSnils(this.patient.snils) || this.patient.snils || '',
+                comment: this.patient.comment || '',
+            };
+            this.originalPatientJson = JSON.stringify(this.editingPatientData);
+            this.editingPatient = true;
+        },
+
+        cancelEditingPatient() {
+            if (this.originalPatientJson) {
+                this.editingPatientData = JSON.parse(this.originalPatientJson);
+            }
+            this.editingPatient = false;
+            this.patientFormError = '';
+        },
+
+        validatePatientForm() {
+            const rules = {
+                address: {
+                    required: true,
+                    message: 'Адрес обязателен',
+                },
+                phone: {
+                    required: true,
+                    message: 'Телефон обязателен',
+                    validator: isValidPhone,
+                    errorMsg: 'Формат: 8(XXX)XXX-XX-XX',
+                },
+                passport: {
+                    required: true,
+                    message: 'Паспорт обязателен',
+                    validator: isValidPassport,
+                    errorMsg: 'Формат: XXXX XXXXXX',
+                },
+                snils: {
+                    required: true,
+                    message: 'СНИЛС обязателен',
+                    validator: isValidSnils,
+                    errorMsg: 'Формат: XXX-XXX-XXX XX',
+                },
+            };
+
+            const errors = validateForm(this.editingPatientData, rules);
+            if (Object.keys(errors).length > 0) {
+                this.patientFormError = Object.values(errors).join('\n');
+                return true;
+            }
+            this.patientFormError = '';
+            return false;
+        },
+
+        async savePatient() {
+            if (this.validatePatientForm()) return;
+
+            const body = {
+                address: this.editingPatientData.address.trim(),
+                smsPhone: formatPhone(this.editingPatientData.phone),
+                passport: formatPassport(this.editingPatientData.passport),
+                healthInsurance: this.editingPatientData.insurance.trim(),
+                snils: formatSnils(this.editingPatientData.snils),
+                comment: this.editingPatientData.comment.trim() || null,
+            };
+
+            try {
+                await patientApi.update(this.id, body);
+
+                this.patient.address = body.address;
+                this.patient.phone = body.smsPhone;
+                this.patient.passport = body.passport;
+                this.patient.insurance = body.healthInsurance;
+                this.patient.snils = body.snils;
+                this.patient.comment = body.comment;
+
+                this.editingPatient = false;
+            } catch (err) {
+                console.error('Ошибка сохранения данных пациента:', err);
+                if (err.response?.status === 422) {
+                    const parsed = parseApiError(err);
+                    if (parsed.violations) {
+                        const messages = parsed.violations.map(v => {
+                            let msg = v.message;
+                            const prefix = `${v.propertyPath}: `;
+                            if (msg.startsWith(prefix)) msg = msg.slice(prefix.length);
+                            return `• ${v.propertyPath}: ${msg}`;
+                        });
+                        this.patientFormError = messages.join('\n');
+                    } else {
+                        this.patientFormError = parsed.generalError || 'Ошибка сохранения';
+                    }
+                } else {
+                    this.patientFormError = 'Не удалось сохранить данные. Проверьте соединение.';
+                }
+            }
+        },
+        onPhoneInput() {
+            this.editingPatientData.phone = formatPhone(this.editingPatientData.phone);
+        },
+        onPassportInput() {
+            this.editingPatientData.passport = formatPassport(this.editingPatientData.passport);
+        },
+        onSnilsInput() {
+            this.editingPatientData.snils = formatSnils(this.editingPatientData.snils);
         },
     }
 };

--- a/frontend/src/components/PatientHistory/PatientHistory.template.html
+++ b/frontend/src/components/PatientHistory/PatientHistory.template.html
@@ -12,6 +12,24 @@
     <div v-if="patient" class="patient-main-content">
         <div class="left-column">
             <div class="patient-info-compact">
+                <div class="treatment-section-header">
+                    <h3>Персональные данные</h3>
+                    <div class="treatment-actions">
+                        <button 
+                            v-if="!editingPatient"
+                            class="btn-edit-treatment"
+                            title="Редактировать данные"
+                            @click="startEditingPatient"
+                        >✎</button>
+                        <template v-if="editingPatient">
+                            <button class="btn-save-treatment" @click="savePatient">Сохранить</button>
+                            <button class="btn-cancel-treatment" @click="cancelEditingPatient">Отмена</button>
+                        </template>
+                    </div>
+                </div>
+
+                <div v-if="patientFormError" class="treatment-form-error">{{ patientFormError }}</div>
+
                 <div class="info-row">
                     <div class="info-group">
                         <label>ФИО:</label>
@@ -22,14 +40,21 @@
                 <div class="info-row">
                     <div class="info-group">
                         <label>Проживание:</label>
-                        <span>{{ patient.address }}</span>
+                        <span v-if="!editingPatient">{{ patient.address }}</span>
+                        <input v-else type="text" v-model="editingPatientData.address" class="edit-input" />
                     </div>
                 </div>
 
                 <div class="info-row">
                     <div class="info-group">
                         <label>Телефон:</label>
-                        <span>{{ patient.phone }}</span>
+                        <span v-if="!editingPatient">{{ patient.phone }}</span>
+                        <input v-else type="text" 
+                            v-model="editingPatientData.phone" 
+                            class="edit-input"
+                            @input="onPhoneInput"
+                            maxlength="15"
+                            placeholder="8(XXX)XXX-XX-XX" />
                     </div>
                 </div>
 
@@ -43,21 +68,35 @@
                 <div class="info-row">
                     <div class="info-group">
                         <label>Паспорт:</label>
-                        <span>{{ patient.passport }}</span>
+                        <span v-if="!editingPatient">{{ patient.passport }}</span>
+                        <input v-else type="text" 
+                            v-model="editingPatientData.passport" 
+                            class="edit-input"
+                            @input="onPassportInput"
+                            maxlength="11"
+                            placeholder="XXXX XXXXXX" />
                     </div>
                 </div>
 
+                <!-- Полис -->
                 <div class="info-row">
                     <div class="info-group">
                         <label>Полис:</label>
-                        <span>{{ patient.insurance }}</span>
+                        <span v-if="!editingPatient">{{ patient.insurance }}</span>
+                        <input v-else type="text" v-model="editingPatientData.insurance" class="edit-input" />
                     </div>
                 </div>
 
                 <div class="info-row">
                     <div class="info-group">
                         <label>СНИЛС:</label>
-                        <span>{{ patient.snils }}</span>
+                        <span v-if="!editingPatient">{{ patient.snils }}</span>
+                        <input v-else type="text" 
+                            v-model="editingPatientData.snils" 
+                            class="edit-input"
+                            @input="onSnilsInput"
+                            maxlength="14"
+                            placeholder="XXX-XXX-XXX XX" />
                     </div>
                 </div>
 
@@ -65,6 +104,14 @@
                     <div class="info-group">
                         <label>ЛПУ:</label>
                         <span>{{ patient.hospital }}</span>
+                    </div>
+                </div>
+
+                <div class="info-row">
+                    <div class="info-group">
+                        <label>Комментарий:</label>
+                        <span v-if="!editingPatient">{{ patient.comment || '—' }}</span>
+                        <input v-else type="text" v-model="editingPatientData.comment" class="edit-input" />
                     </div>
                 </div>
 


### PR DESCRIPTION
Цель: Обеспечить возможность редактирования контактных данных и документов пациента непосредственно в карточке, с отправкой изменений на сервер через PATCH-запрос.

Исходное состояние: Поля персональных данных отображаются статично.
Требования к реализации:
    1. Кнопка переключения режима
        ◦ В правом верхнем углу блока patient-info-compact разместить кнопку « Редактировать» (или «Сохранить» в режиме редактирования).
        ◦ При клике editingPatient переключается между true и false.
    2. Переключение интерфейса
        ◦ Редактируемые поля: address, smsPhone, passport, healthInsurance, snils, comment.
        ◦ Все поля ввода предзаполнены текущими значениями из this.patient.
    3. Сохранение изменений
        ◦ PATCH на /api/patients/{id}.
        ◦ После успеха: editingPatient = false, локальные данные обновляются.
    4. Отмена изменений
        ◦ Кнопка «Отмена», возврат к исходным значениям.
    5. Валидация
        ◦ Телефон, паспорт, СНИЛС — проверка по маскам. Обязательные поля не пустые.
Ожидаемый результат: Врач может отредактировать персональные данные пациента на месте, с валидацией и сохранением на сервер.