### PR TITLE
Добавляем --no-scripts и --env=prod для предотвращения конфликта с WebProfilerBundle на проде

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     networks:
       - default
     command: >
-      sh -c "composer install --no-dev --optimize-autoloader --no-interaction
-      && php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+      sh -c "composer install --no-dev --no-scripts --optimize-autoloader --no-interaction
+      && php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration --env=prod
       && php bin/console cache:clear --env=prod --no-debug
       && php bin/console cache:warmup --env=prod
       && php-fpm"


### PR DESCRIPTION
Добавляем --no-scripts и --env=prod для предотвращения конфликта с WebProfilerBundle на проде