### PR TITLE
3.1 Аквариум (трассировка) + секции статьи

### DIFF
--- a/docs/03-Задачи/Спринты/Спринт-03/3.1. Интеграция мессенджера MAX.md
+++ b/docs/03-Задачи/Спринты/Спринт-03/3.1. Интеграция мессенджера MAX.md
@@ -151,6 +151,23 @@ depends_on: []
 ## Тесты (TDD)
 <!-- Эйприл: скелеты. Дев: дополнение. -->
 
+Покрытие (Майк, 177/177 зелёных, 490 assertions):
+
+| Тест | Что покрывает |
+|---|---|
+| `Service/MaxChannelTest.php` | успешная отправка (URL/заголовки/тело/chat_id), 5xx→`retryable`, 4xx→без повторов, текст > 4000 → исключение до HTTP, пустой `address`→failure, `strip_tags`, `isAvailable()` |
+| `Service/NotificationServiceTest.php` | резолв адреса → канал вызван с адресом; `null`-адрес → `failed` и канал НЕ вызван; ретраи (первичная + до 3); 4xx без повторов; ROUTINE через Messenger; обработчик конверта |
+| `Service/NotificationServiceIntegrationTest.php` | полный цикл с реальной БД (TemplateResolver + NotificationLogRepository) |
+| `Service/NotificationServiceMessengerRoutingTest.php` | ROUTINE уходит в async-транспорт, не выполняется inline |
+| `Service/PatientContactResolverTest.php` | адрес по patientId+channelType; `null` при отсутствии записи / patientId<1 |
+| `Service/ExponentialRetrySleeperTest.php` | задержки 1s/5s/25s |
+| `Service/MaxUpdatePollerTest.php`, `MaxUpdateProcessorTest.php`, `MaxWebhookClientTest.php`, `MaxDeepLinkGeneratorTest.php` | Long Polling / обработка `bot_started` / webhook-подписка / генерация диплинка |
+| `Controller/MaxWebhookControllerTest.php`, `MaxWebhookApiTest.php` | валидный/невалидный секрет; публичность эндпоинта; сохранение контакта из `bot_started` |
+| `Command/*Test.php` | команды `collect-max-contacts` / `test-max` / `max-webhook-subscribe` |
+| `Model/RecipientTest.php`, `Service/FakeChannel.php` | адаптированы под новую сигнатуру `send(Recipient, string, NotificationMessage)` |
+
+Запуск: `docker compose run --rm -e MAX_API_URL=test -e MAX_BOT_TOKEN=test -e MAX_WEBHOOK_SECRET=test-webhook-secret php vendor/bin/phpunit` → **OK (177 tests, 490 assertions)**.
+
 ## Реализация
 
 ### План разработки
@@ -381,8 +398,165 @@ public function __construct(
     
 - Убедиться, что `MAX_BOT_TOKEN` не попал в Git.
 
+### Обзор технологий (реализация)
+
+Стек: Symfony 7.3 + API Platform 4 + Doctrine ORM; `symfony/http-client` (запросы к MAX); `symfony/messenger` (асинхронная доставка ROUTINE); свой экспоненциальный ретрай.
+
+| Компонент | Файл | Роль |
+|---|---|---|
+| Контакт канала | `Entity/PatientChannelIdentity.php` | таблица `patient_channel_identities` (`patient_id`, `channel_type`, `value`), unique `(patient_id, channel_type)`; `#[ApiResource]` + фильтр `SearchFilter(patientId)` |
+| Защищённый диплинк | `Entity/MaxDeepLink.php` | таблица `max_deeplinks` (`patient_id`, `token`), unique `(patient_id)` и `(token)` |
+| Резолвер адреса | `Service/PatientContactResolver.php` | `get(patientId, channelType): ?string` |
+| Канал MAX | `Service/MaxChannel.php` | `POST {MAX_API_URL}/messages` (query `chat_id`, `Authorization: token`, json `text` ≤ 4000, `timeout` 10s, `strip_tags`, throttle 0.5s) |
+| Long Polling | `Service/MaxUpdatePoller.php` | `GET /updates` (marker, types, limit, timeout) |
+| Обработчик обновлений | `Service/MaxUpdateProcessor.php` | `bot_started` → резолв токена диплинка → upsert контакта |
+| Webhook-клиент | `Service/MaxWebhookClient.php` | `POST/GET/DELETE /subscriptions` |
+| Генератор диплинка | `Service/MaxDeepLinkGenerator.php` | `https://max.ru/<бот>?start=<token>` (token = 32 hex из `random_bytes(16)`) |
+| Ретраи | `Service/RetrySleeperInterface.php` + `ExponentialRetrySleeper.php` | задержки 1s/5s/25s |
+| Webhook-контроллер | `Controller/MaxWebhookController.php` | `POST /api/max/webhook`, проверка `X-Max-Bot-Api-Secret` через `hash_equals` |
+| Диплинк-контроллер | `Controller/MaxDeepLinkController.php` | `GET /api/patients/{id}/max-deeplink` |
+| Команды | `Command/CollectMaxContactsCommand.php`, `TestMaxNotificationCommand.php`, `MaxWebhookSubscribeCommand.php` | Long Polling loop / ручная проверка / регистрация webhook |
+
+Ключевые решения и отступления от плана:
+- `Recipient` упрощён до `patientId`+`treatmentId` (адреса вынесены в `PatientChannelIdentity`), метод `addressFor()` удалён.
+- `ChannelInterface::send()` получил `string $address` (новый 2-й аргумент).
+- `SendResult` расширен: `externalId`, `retryable`, `status` (`sent`/`delivered`/`failed`). В плане ретраи упоминались как «остаётся», но в коде их не было — реализованы в этой задаче (`sendWithRetries()` + `ExponentialRetrySleeper`).
+- `NotificationService::deliver()` резолвит адрес до отправки; при `null` — `failed` + (IMMEDIATE → `NotificationDeliveryException`, ROUTINE → переход к следующему каналу).
+- MAX не возвращает message_id/статус доставки в ответе на `POST /messages` → `externalId` остаётся `null`, успех трактуется как `sent`.
+
+Запросы к БД (индексы):
+- `PatientContactResolver` → `findOneByPatientAndChannel` — точечный lookup по уникальному индексу `uniq_patient_channel_identity (patient_id, channel_type)`.
+- `MaxDeepLinkRepository::findByToken` — уникальный индекс `uniq_max_deeplink_token`.
+- `PatientChannelIdentityRepository::findByPatient` — левая часть составного индекса `(patient_id, channel_type)`.
+
+Безопасность: секреты только в `.env` (gitignored) и `api/.env.test` (заглушки); в git — `change_me`/`test`. Webhook публичен, но валидирует секрет. Диплинк использует случайный токен (не `patientId`) — перебор исключён.
+
 ## Аквариум
 <!-- Майк → Эйприл: трассировка вход → функции/файлы → выход. -->
+
+**Идея.** Двусторонняя интеграция мессенджера MAX: (1) исходящие уведомления врача пациенту — канал `max` находит `chat_id` в отдельной таблице контактов, шлёт HTTP-запрос в MAX и пишет результат в лог, с экспоненциальными ретраями для временных ошибок; (2) фундамент входящего канала — привязка `chat_id` пациента через защищённый диплинк (случайный токен вместо открытого `patientId`) и приём событий через Long Polling / Webhook. Технологии: Symfony 7 + API Platform (CRUD контактов), `symfony/http-client` (запросы к MAX), `symfony/messenger` (асинхронная доставка ROUTINE). Паттерны: реестр каналов (`ChannelRegistry` + тег `communication.channel`), резолвер адреса (`PatientContactResolver`), экспоненциальный ретрай (`ExponentialRetrySleeper`), защищённый токен диплинка.
+
+### Сценарий 1. Отправка уведомления через MAX (СЦ-3.1.7, позитив)
+
+**Идея:** врач отправляет пациенту 42 сообщение «Доза 5 мг» через MAX; система находит `chat_id`, шлёт HTTP-запрос в MAX и пишет `sent` в лог.
+
+**По шагам:**
+
+1. **`NotificationService::send(Recipient(patientId: 42), NotificationMessage(body: 'Доза 5 мг'), ['max'], Priority::IMMEDIATE)`**
+   Входные переменные: `patientId = 42`, `body = 'Доза 5 мг'`, `channels = ['max']`, приоритет `IMMEDIATE`. IMMEDIATE означает синхронную отправку: ошибка пробрасывается вызывающему коду, а не молча логируется.
+
+2. **`deliver(rethrow: true)` → `ChannelRegistry::get('max')`**
+   Достаём из реестра канал по ключу `'max'`. Переменная `$channel = MaxChannel`. *Паттерн «реестр»: канал ищется по строке без if/switch — новый канал добавляется регистрацией сервиса с тегом `communication.channel`.*
+
+3. **`MaxChannel::isAvailable()`**
+   Проверяет, что в `.env` заданы `MAX_API_URL` и `MAX_BOT_TOKEN`. → `true` (`MAX_API_URL = 'https://platform-api2.max.ru'`).
+
+4. **`PatientContactResolver::get(42, 'max')`**
+   Запрос `SELECT value FROM patient_channel_identities WHERE patient_id=42 AND channel_type='max'` по уникальному индексу `(patient_id, channel_type)`. На выходе `$address = '42342534'` — это `chat_id` пациента. *Паттерн «резолвер»: отделяет «кто» (Recipient с `patientId`) от «куда» (адрес) — адреса живут отдельно от пациента, новый канал не требует правки `Patient`/`Recipient`.*
+
+5. **`TemplateResolver::resolve(message, 'max')`**
+   Подстановка плейсхолдеров `%key%`. Здесь плейсхолдеров нет → текст остаётся `'Доза 5 мг'`.
+
+6. **`MaxChannel::send($recipient, '42342534', 'Доза 5 мг')`**
+   Сначала троттлинг (не чаще 0.5 с между запросами) и проверка длины (≤ 4000 — ок). Затем HTTP: `POST https://platform-api2.max.ru/messages?chat_id=42342534`, заголовки `Authorization: <токен>` и `Content-Type: application/json`, тело `{"text":"Доза 5 мг"}`, `timeout=10`. Ответ `200` → `SendResult::success()`: `status='sent'`, `externalId=null` (MAX не возвращает id сообщения).
+
+7. **`log(...)` → `NotificationLog`**
+   Пишет строку: `patient_id=42`, `channel_type='max'`, `recipient_address='42342534'`, `status='sent'`, `external_id=null`.
+
+**Выход:** сообщение доставлено; в `notification_logs` — `status='sent'`, `recipient_address='42342534'`.
+
+*Движение данных:* `patientId=42 → chat_id='42342534' → тело POST {"text":"Доза 5 мг"} → notification_logs.status='sent'`.
+
+*Примечание (ROUTINE):* при `Priority::ROUTINE` шаг 1 вместо синхронной отправки кладёт `SendNotificationEnvelope` в Messenger (транспорт `async`); воркер вызывает `handleEnvelope()` → тот же `deliver(rethrow: false)`. Разница — ошибка только логируется, не пробрасывается.
+
+### Сценарий 2. Временная ошибка MAX → ретраи (СЦ-3.1.10)
+
+**Идея:** MAX отвечает `5xx` — система повторяет отправку с экспоненциальной задержкой; `4xx` не ретраится.
+
+**По шагам:**
+
+1. **`MaxChannel::send($recipient, '42342534', 'Доза 5 мг')`** — HTTP POST возвращает `500`. → `SendResult::failure('MAX API returned HTTP 500.', retryable: true)`.
+2. **`NotificationService::sendWithRetries()`** — видит `success=false, retryable=true`. Ждёт `ExponentialRetrySleeper::wait(0)` → 1 с, повторяет `attemptSend()`. Снова `500` → `wait(1)` → 5 с, повтор. Снова → `wait(2)` → 25 с, повтор. Итого 1 первичная + 3 повтора.
+3. **`log(...)`** — после 4 неудач: `status='failed'`, `error_message='MAX API returned HTTP 500.'`.
+
+**Выход:** после исчерпания повторов — `notification_logs.status='failed'`.
+
+*Противоположный случай (`4xx`):* `400/401/403` → `SendResult::failure(..., retryable: false)` → `sendWithRetries()` не повторяет, сразу `failed`. *Решение: ретраить только временные ошибки, чтобы не «долбить» MAX при неверном токене или адресате.*
+
+### Сценарий 3. Негативы отправки (СЦ-3.1.8, 3.1.9, 3.1.11)
+
+**Идея:** три случая, когда до HTTP-запроса к MAX дело не доходит — система пишет `failed` и не вызывает канал.
+
+**Вариант А — контакт не настроен (СЦ-3.1.8):**
+1. `deliver()` → `PatientContactResolver::get(42, 'max')` → записи нет → `$address = null`.
+2. `log(...)`: `status='failed'`, `error_message='Address not configured for channel "max".'`. `MaxChannel::send()` НЕ вызывается.
+3. `IMMEDIATE` → `NotificationDeliveryException`; `ROUTINE` → переход к следующему каналу.
+
+**Вариант Б — канал недоступен (СЦ-3.1.9):**
+`MaxChannel::isAvailable()` → `false` (пустой `MAX_API_URL`/`MAX_BOT_TOKEN`) → `status='failed'`, `error_message='Channel "max" is not available.'`.
+
+**Вариант В — текст > 4000 (СЦ-3.1.11):**
+`MaxChannel::assertValidText()` → `InvalidArgumentException` до HTTP-запроса; `attemptSend()` ловит → `SendResult::failure` → `status='failed'`.
+
+**Выход:** во всех трёх случаях `notification_logs.status='failed'`, без HTTP-запроса к MAX.
+
+### Сценарий 4. CRUD контактов канала (СЦ-3.1.1, 3.1.2, 3.1.3)
+
+**Идея:** врач управляет контактами пациента через API Platform; контакт `max` уникален на `(patient_id, channel_type)`, значение — без пробелов.
+
+**Создание (СЦ-3.1.1):**
+1. `POST /api/patient_channel_identities`, тело `{"patientId": 42, "channelType": "max", "value": "42342534"}`.
+2. API Platform → сущность `PatientChannelIdentity`, десериализация по группе `patient_channel_identity:write`.
+3. Валидация `NotBlank`, `Length(max=255)`, `Regex(/^\S+$/)` → ок → persist → `201`.
+4. В БД строка: `patient_id=42`, `channel_type='max'`, `value='42342534'`.
+
+**Дубликат (СЦ-3.1.2):** повторный POST с тем же `channelType='max'` → нарушение уникального индекса `(patient_id, channel_type)` → `409`.
+
+**Некорректное значение (СЦ-3.1.3):** `value=''`, длиннее 255 или с пробелом → `NotBlank`/`Length`/`Regex` → `422`.
+
+**Выход:** `201` при создании; `409` при дубле; `422` при невалидном значении. *Паттерн: адреса каналов вынесены в отдельную сущность с уникальностью, а не в поля `Patient` — новый канал добавляется без миграции `patients`.*
+
+### Сценарий 5. Выдача диплинка врачу (СЦ-3.1.4, позитив)
+
+**Идея:** врач запрашивает ссылку для пациента; система выдаёт ссылку со случайным токеном, не раскрывая `patientId`.
+
+**По шагам:**
+
+1. **`GET /api/patients/42/max-deeplink`** (JWT врача).
+2. **`MaxDeepLinkController::__invoke(42)`** — проверяет, что пациент существует → **`MaxDeepLinkGenerator::forPatient(42)`**.
+3. `MaxDeepLinkRepository::findByPatientId(42)` → `null` (диплинка ещё нет) → создаёт `MaxDeepLink(patientId: 42, token: 'a1b2c3d4e5f60718293a4b5c6d7e8f90')`, где токен = `bin2hex(random_bytes(16))` (32 символа) → persist + flush.
+4. Возвращает `{"url": "https://max.ru/id463246156997_bot?start=a1b2c3d4e5f60718293a4b5c6d7e8f90"}`.
+
+**Выход:** диплинк выдан; в `max_deeplinks` — строка `patient_id=42`, `token='a1b2c3d4e5f60718293a4b5c6d7e8f90'`. *Решение: в ссылке случайный токен вместо `patientId` — чужой диплинк нельзя подобрать перебором.*
+
+### Сценарий 6. Привязка chat_id при bot_started (СЦ-3.1.5, 3.1.6)
+
+**Идея:** пациент открыл бота по диплинку; MAX прислал `bot_started` с токеном и `chat_id`; система резолвит токен и сохраняет контакт.
+
+**По шагам (позитив, СЦ-3.1.5):**
+
+1. Контейнер `max-updates-listener` → **`CollectMaxContactsCommand`** → **`MaxUpdatePoller::fetch()`** → `GET /updates` → событие `{"update_type":"bot_started","chat_id":42342534,"payload":"a1b2c3d4e5f60718293a4b5c6d7e8f90"}`.
+2. **`MaxUpdateProcessor::process($update)`** → `MaxDeepLinkRepository::findByToken('a1b2c3d4e5f60718293a4b5c6d7e8f90')` → `MaxDeepLink(patientId=42)`. → `patientId = 42`.
+3. `upsertContact(42, '42342534')` → `PatientChannelIdentityRepository::findOneByPatientAndChannel(42, 'max')` → `null` → создаёт `PatientChannelIdentity(patientId=42, channelType='max', value='42342534')` + persist.
+4. `flush()`.
+
+**Негатив (СЦ-3.1.6):** токена нет в `max_deeplinks` → `process()` возвращает `null` → событие молча игнорируется, контакт не создаётся. *Решение: не отвечаем ошибкой на неизвестный токен — не даём злоумышленнику перебирать валидные токены.*
+
+**Выход:** контакт `max` (`chat_id='42342534'`) сохранён; неизвестный токен — игнор без ошибки.
+
+### Сценарий 7. Webhook с неверным секретом (СЦ-3.1.12, security)
+
+**Идея:** входящее событие через Webhook; эндпоинт публичен (вне JWT), но проверяет секрет в заголовке.
+
+**По шагам:**
+
+1. **`POST /api/max/webhook`**, заголовок `X-Max-Bot-Api-Secret: wrong` (или отсутствует), тело — событие.
+2. **`MaxWebhookController::__invoke($request)`** → `hash_equals($webhookSecret, 'wrong')` → `false` (или секрет не задан).
+3. → `403 {"error":"Invalid secret."}`. Событие НЕ обрабатывается (`MaxUpdateProcessor` не вызывается).
+
+**Выход:** `403`, без записи в БД. *Решение: публичный эндпоинт защищён секретом через `hash_equals` — сравнение, устойчивое к атакам по времени.*
+
+> СЦ-3.1.13 / СЦ-3.1.14 (приём дозы через бота) — перспектива задачи 4.3; в 3.1 заложена только инфраструктура привязки контакта и входящего канала.
 
 ## Ручное тестирование
 <!-- Марк: блок на русском + ссылка на postman-коллекцию. -->
@@ -404,4 +578,6 @@ public function __construct(
 
 22.08.26 Ян (РП): скелет переработан под новый шаблон. Волна 1: → Федя (Бизнес-логика + Сценарии). Далее → Эйприл (архитектура, финальная постановка, план, TDD) → Майк (Аквариум) → Эйприл (ревью). e2e → Марк после 3.20 (Юлий).
 23.08.26 Федя: Ревью Яна (PR #75) — исправил ссылку на приём дозы через бота: 3.13 → 4.3 (актуальная нумерация из «План спринтов.md»). → Лид (Эйприл)
+
+23.08.26 Майк: реализация MAX найдена в ветке `3_1_max_api_integration` (10 коммитов), не была в `develop`. Восстановил: ветка `3_1_max_recovery` от develop, cherry-pick 10 коммитов без конфликтов, тесты зелёные (177/177), PR #71. Заполнил секции «Тесты (TDD)», «Реализация» (обзор технологий) и «Аквариум» (трассировка) → Эйприл (верификация).
 


### PR DESCRIPTION
## Задача
3.1 — Интеграция мессенджера MAX (секции статьи: «Аквариум», «Тесты (TDD)», «Реализация»)

## Что сделано
Заполнены секции статьи задачи:
- **«Аквариум»** — трассировка в стиле дебаггера по скиллу `write-aquarium`: «Идея» в начале + 7 сценариев, привязанных к аналитике (СЦ-3.1.1–3.1.12), с фактическими значениями переменных, движением данных и встроенными паттернами.
- **«Тесты (TDD)»** — таблица покрытия + команда запуска (177/177 зелёных).
- **«Реализация»** — обзор технологий, ключевые решения, отступления от плана, индексы БД, security-заметки.
- **«Комментарии»** — запись о восстановлении кода.

## Критерии приёмки
- [x] «Идея» есть в начале «Аквариума»
- [x] Каждый сценарий: Вход → шаги → Выход
- [x] В шагах — фактические значения переменных и движение данных
- [x] Паттерны/архитектурные решения встроены в шаги

## Тесты
Код не менялся — backend-тесты 177/177 (зелёные, PR #71).

## Как проверить
Открыть статью `docs/03-Задачи/Спринты/Спринт-03/3.1. Интеграция мессенджера MAX.md`, секции «Аквариум» / «Тесты (TDD)» / «Реализация».

## Аквариум
Секция «Аквариум» статьи задачи (этот PR).
