### PR TITLE
3.24 Изоляция docker-compose стеков агентов

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -22,3 +22,10 @@ MAX_WEBHOOK_SECRET=change_me
 # Ник бота MAX (из публичной ссылки max.ru/<ник> или GET /me → username).
 MAX_BOT_NICKNAME=id463246156997_bot
 ###< MAX мессенджер ###
+
+###> Docker isolation (уникальные для каждого агента) ###
+COMPOSE_PROJECT_NAME=ibs_<агент>   # префикс имён контейнеров/образов/томов (напр. ibs_jul)
+APP_PORT=8081                      # nginx наружу (у агентов: 8001–8005)
+DB_PORT=5432                       # PostgreSQL наружу (5441–5445)
+FRONTEND_PORT=5174                 # Vite dev-сервер наружу (5181–5185)
+###< Docker isolation ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
       - db_data:/var/lib/postgresql/data
+    ports:
+      - "${DB_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
@@ -107,6 +109,8 @@ services:
     volumes:
       - ./frontend:/app
       - frontend_dist:/app/dist
+    ports:
+      - "${FRONTEND_PORT:-5174}:5173"
     command: sh -c "npm ci && npm run build"
     networks:
       - default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: .
       dockerfile: docker/php/Dockerfile
-    container_name: ibs-php
     working_dir: /var/www/html
     volumes:
       - ./api:/var/www/html
@@ -35,7 +34,6 @@ services:
     build:
       context: .
       dockerfile: docker/php/Dockerfile
-    container_name: ibs-messenger-worker
     working_dir: /var/www/html
     volumes:
       - ./api:/var/www/html
@@ -63,7 +61,6 @@ services:
     build:
       context: .
       dockerfile: docker/php/Dockerfile
-    container_name: ibs-max-updates-listener
     working_dir: /var/www/html
     volumes:
       - ./api:/var/www/html
@@ -89,7 +86,6 @@ services:
 
   db:
     image: postgres:15
-    container_name: ibs-db
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -107,7 +103,6 @@ services:
 
   node:
     image: node:20-alpine
-    container_name: ibs-node
     working_dir: /app
     volumes:
       - ./frontend:/app
@@ -119,13 +114,12 @@ services:
 
   nginx:
     image: nginx:alpine
-    container_name: ibs-nginx
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
       - ./api/public:/var/www/html/public:ro
       - frontend_dist:/var/www/html/frontend:ro
     ports:
-      - "8081:80"
+      - "${APP_PORT:-8081}:80"
     depends_on:
       php:
         condition: service_started
@@ -142,7 +136,6 @@ services:
     build: ./tests/e2e
     # Профиль: `docker compose up` не стартует e2e — тесты гоняются по требованию.
     profiles: ["e2e"]
-    container_name: ibs-e2e
     working_dir: /e2e
     volumes:
       - ./tests/e2e:/e2e

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -26,7 +26,7 @@ server {
 
     # Главный PHP-обработчик (ловит внутренние редиректы на /index.php)
     location ~ ^/index\.php(/|$) {
-        fastcgi_pass ibs-php:9000;
+        fastcgi_pass php:9000;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /var/www/html/public/index.php;


### PR DESCRIPTION
## Задача
3.24 — Изоляция docker-compose стеков агентов ([[3.24. Изоляция docker-compose стеков агентов]])

## Что сделано
- Убран `container_name` из всех сервисов `docker-compose.yml` (7 шт.) — контейнеры автоименуются `${COMPOSE_PROJECT_NAME}-<service>-1`.
- Порт nginx вынесен в `.env` (`APP_PORT`), fallback `8081`.
- `nginx/default.conf`: `fastcgi_pass ibs-php:9000` → `php:9000` (иначе связка ломается без container_name).
- `.env.dist`: добавлена секция «Docker isolation» (`COMPOSE_PROJECT_NAME`/`APP_PORT`/`DB_PORT`/`FRONTEND_PORT`).

## Критерии приёмки
- [x] В `docker-compose.yml` нет `container_name`
- [x] Порт nginx берётся из `.env` (`APP_PORT`)
- [x] Два стека с разными `COMPOSE_PROJECT_NAME` поднимаются параллельно (проверено: `ibs_jul` + `ibs_test2`, уникальные имена/порты, кросс-обращений нет)
- [ ] Прод (VPS) не затронут; разница локали/прода зафиксирована — **блокировано: нет SSH-доступа**

## Тесты
- `docker compose config` — валиден.
- Параллельный запуск двух стеков (`ibs_jul` + `ibs_test2`) — оба поднялись; `php` резолвится в свой контейнер (nginx A→172.27.0.9, nginx B→172.27.0.14).

## Как проверить
1. `docker compose up -d` (свой стек)
2. `COMPOSE_PROJECT_NAME=ibs_test2 APP_PORT=8006 DB_PORT=5446 FRONTEND_PORT=5186 docker compose up -d`
3. `curl localhost:8003/api/` и `curl localhost:8006/api/` → 401 (JWT)

## Аквариум
—
