### PR TITLE
3.32 Динамический VITE_API_URL для фронтенда

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ docker-compose.override.yml
 .env
 
 frontend/.env.production
+frontend/.env.local
 
 # Python (скрипты регистрации 4.7)
 .venv/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,8 @@ services:
       - frontend_dist:/app/dist
     ports:
       - "${FRONTEND_PORT:-5174}:5173"
+    environment:
+      VITE_API_URL: "http://localhost:${APP_PORT}/api"
     command: sh -c "npm ci && npm run build"
     networks:
       - default

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,0 @@
-VITE_API_URL=http://localhost:8081/api

--- a/frontend/src/modules/shared/api/client.js
+++ b/frontend/src/modules/shared/api/client.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8081/api';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
 const apiClient = axios.create({
     baseURL: API_BASE_URL,


### PR DESCRIPTION
## Задача
3.32 — Динамический VITE_API_URL для фронтенда (убрать хардкод порта)

## Что сделано
- `docker-compose.yml`: сервису `node` передаётся `VITE_API_URL: http://localhost:${APP_PORT}/api` — фронт у каждого агента собирается со своим портом API (из `APP_PORT`).
- `frontend/.env.local` убран из git (`git rm --cached` + строка в `.gitignore`); локальный файл у агентов остаётся.
- `client.js`: фолбэк `http://localhost:8081/api` → `/api` (устранён последний хардкод порта 8081).

## Критерии приёмки
- [x] `VITE_API_URL` формируется из `APP_PORT`, хардкода `8081` в репо нет
- [x] `frontend/.env.local` не в git (в `.gitignore`)
- [x] После подъёма стека фронт авторизуется без `CORS`/`Network Error` (сборка инлайнит `localhost:8003`, API `401` + CORS-заголовок)
- [x] Прод (VPS) не затронут (на проде `.env.production` = `VITE_API_URL=/api`, same-origin)

## Тесты
- `docker compose config` → `node.environment.VITE_API_URL = http://localhost:8003/api`.
- Сборка фронта → в dist `localhost:8003`, `8081` нет.
- Стек поднят → API `401`, CORS `Access-Control-Allow-Origin: http://localhost:5183`.

## Как проверить
1. `docker compose up -d`
2. `docker compose run --rm node sh -c 'echo $VITE_API_URL'` → `http://localhost:<APP_PORT>/api`
3. Логин в UI без `CORS`/`Network Error`

## Аквариум
—
