### PR TITLE
3.26 CI: автозапуск тестов на PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,27 @@ jobs:
         run: |
           composer validate --strict
           composer audit
+
+  frontend:
+    name: Frontend (Node 20)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: npm ci
+        working-directory: frontend
+        run: npm ci
+
+      - name: Vitest
+        working-directory: frontend
+        run: npm run test
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+
+jobs:
+  backend:
+    name: Backend (PHP 8.3)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: symfony
+          POSTGRES_PASSWORD: symfony
+          POSTGRES_DB: symfony
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U symfony -d symfony"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://symfony:symfony@127.0.0.1:5432/symfony?serverVersion=15&charset=utf8
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: pdo_pgsql, mbstring, intl, pcntl, bcmath, gd, exif, mysqli, zip
+          coverage: none
+          tools: composer:v2
+
+      - name: Composer install
+        working-directory: api
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Migrations + schema validate
+        working-directory: api
+        run: |
+          php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+          php bin/console doctrine:schema:validate
+
+      - name: Create test DB + migrate
+        working-directory: api
+        run: |
+          php bin/console doctrine:database:create --env=test --if-not-exists
+          php bin/console doctrine:migrations:migrate --env=test --no-interaction --allow-no-migration
+
+      - name: PHPUnit
+        working-directory: api
+        run: vendor/bin/phpunit
+
+      - name: PHPStan
+        working-directory: api
+        run: |
+          php bin/console cache:warmup --env=dev
+          vendor/bin/phpstan analyse --no-progress
+
+      - name: Composer validate + audit
+        working-directory: api
+        run: |
+          composer validate --strict
+          composer audit

--- a/api/composer.json
+++ b/api/composer.json
@@ -1,4 +1,6 @@
 {
+    "name": "ibs/cardionavigator",
+    "description": "КардиоНавигатор — система ведения пациентов (антикоагулянтная терапия)",
     "type": "project",
     "license": "proprietary",
     "minimum-stability": "stable",
@@ -13,7 +15,7 @@
         "doctrine/doctrine-bundle": "^2.18.2",
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6.2",
-        "lexik/jwt-authentication-bundle": "*",
+        "lexik/jwt-authentication-bundle": "^3.2",
         "nelmio/cors-bundle": "^2.6.1",
         "phpdocumentor/reflection-docblock": "^5.6.6",
         "phpstan/phpdoc-parser": "^2.3.2",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "92c8ec3968907c98ecc7ba0fd2604ab5",
+    "content-hash": "f71c507ae4458d54ae0825e06f19d58c",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -10383,7 +10383,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -10391,6 +10391,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Задача
3.26 — CI: автозапуск тестов на PR (GitHub Actions)

## Что сделано
- `.github/workflows/ci.yml`: **backend** job (php 8.3 + `postgres:15`) — `composer install` → `migrations` + `schema:validate` → create `symfony_test` + migrate `--env=test` → `phpunit` → `phpstan` (после `cache:warmup --env=dev`) → `composer validate --strict` + `composer audit`.
- **frontend** job (node 20) — `npm ci` → `vitest` → `npm run build`.
- `api/composer.json`: добавлены `name`/`description`, pin `lexik/jwt-authentication-bundle` `^3.2` (для `composer validate --strict`); `composer.lock` синхронизирован (content-hash).

## Критерии приёмки
- [ ] PR получает статус-чек (phpunit / phpstan / schema / frontend)
- [ ] Падение любого шага → красный чек
- [ ] Инструкция (при необходимости) в `06-DevOps/Инструкции/`

## Тесты
- `composer validate --strict` → exit 0 (проверено локально).
- Workflow синтаксически валиден (backend + frontend jobs).

## Как проверить
- Статус-чек `CI` на этом PR (зелёный/красный) — это и есть проверка автозапуска.

## Аквариум
—
