### PR TITLE
3.39 Баг BUG-3.1-01: дубликат PatientChannelIdentity → 409

### DIFF
--- a/api/src/Ibs/Context/Communication/Entity/PatientChannelIdentity.php
+++ b/api/src/Ibs/Context/Communication/Entity/PatientChannelIdentity.php
@@ -12,6 +12,7 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
+use Ibs\Context\Communication\State\PatientChannelIdentityProcessor;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -19,9 +20,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     operations: [
         new GetCollection(),
-        new Post(),
+        new Post(processor: PatientChannelIdentityProcessor::class),
         new Get(),
-        new Put(),
+        new Put(processor: PatientChannelIdentityProcessor::class),
         new Delete(),
     ],
     normalizationContext: ['groups' => ['patient_channel_identity:read']],

--- a/api/src/Ibs/Context/Communication/State/PatientChannelIdentityProcessor.php
+++ b/api/src/Ibs/Context/Communication/State/PatientChannelIdentityProcessor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ibs\Context\Communication\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Ibs\Context\Communication\Entity\PatientChannelIdentity;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+/**
+ * Оборачивает persist PatientChannelIdentity и маппит нарушение уникальности
+ * (patient_id, channel_type) в HTTP 409 Conflict вместо 500.
+ */
+final class PatientChannelIdentityProcessor implements ProcessorInterface
+{
+    public function __construct(
+        #[Autowire('@api_platform.doctrine.orm.state.persist_processor')]
+        private ProcessorInterface $persistProcessor,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): PatientChannelIdentity
+    {
+        try {
+            return $this->persistProcessor->process($data, $operation, $uriVariables, $context);
+        } catch (UniqueConstraintViolationException) {
+            throw new ConflictHttpException('Контакт для данного пациента и канала уже существует.');
+        }
+    }
+}

--- a/api/src/Ibs/Context/Communication/State/PatientChannelIdentityProcessor.php
+++ b/api/src/Ibs/Context/Communication/State/PatientChannelIdentityProcessor.php
@@ -14,6 +14,9 @@ use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 /**
  * Оборачивает persist PatientChannelIdentity и маппит нарушение уникальности
  * (patient_id, channel_type) в HTTP 409 Conflict вместо 500.
+ *
+ * Ловим только UniqueConstraintViolationException: прочие нарушения БД
+ * (not-null, FK) остаются 500 — для данного бага достаточно.
  */
 final class PatientChannelIdentityProcessor implements ProcessorInterface
 {

--- a/api/tests/Ibs/Context/Communication/Entity/PatientChannelIdentityApiTest.php
+++ b/api/tests/Ibs/Context/Communication/Entity/PatientChannelIdentityApiTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Ibs\Context\Communication\Entity;
+
+use App\Tests\Support\AuthenticatesUsers;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class PatientChannelIdentityApiTest extends WebTestCase
+{
+    use AuthenticatesUsers;
+
+    private KernelBrowser $client;
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->client->disableReboot();
+
+        $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $this->entityManager->getConnection()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $connection = $this->entityManager->getConnection();
+        if ($connection->isTransactionActive()) {
+            $connection->rollBack();
+        }
+
+        $this->entityManager->close();
+
+        parent::tearDown();
+    }
+
+    public function testCreateContactReturns201(): void
+    {
+        $token = $this->createAuthenticatedClient($this->client, $this->entityManager);
+
+        $this->client->request(
+            'POST',
+            '/api/patient_channel_identities',
+            server: array_merge($this->authHeader($token), ['CONTENT_TYPE' => 'application/json']),
+            content: json_encode([
+                'patientId' => 42,
+                'channelType' => 'max',
+                'value' => '42342534',
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(201, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testDuplicateContactReturns409(): void
+    {
+        $token = $this->createAuthenticatedClient($this->client, $this->entityManager);
+
+        $body = json_encode([
+            'patientId' => 42,
+            'channelType' => 'max',
+            'value' => '42342534',
+        ], JSON_THROW_ON_ERROR);
+
+        $server = array_merge($this->authHeader($token), ['CONTENT_TYPE' => 'application/json']);
+
+        $this->client->request('POST', '/api/patient_channel_identities', server: $server, content: $body);
+        $this->assertSame(201, $this->client->getResponse()->getStatusCode());
+
+        $this->client->request('POST', '/api/patient_channel_identities', server: $server, content: $body);
+        $this->assertSame(409, $this->client->getResponse()->getStatusCode());
+    }
+}

--- a/api/tests/Ibs/Context/Communication/Entity/PatientChannelIdentityApiTest.php
+++ b/api/tests/Ibs/Context/Communication/Entity/PatientChannelIdentityApiTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Ibs\Context\Communication\Entity;
 
 use App\Tests\Support\AuthenticatesUsers;
 use Doctrine\ORM\EntityManagerInterface;
+use Ibs\Context\Communication\Entity\PatientChannelIdentity;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -72,5 +73,13 @@ class PatientChannelIdentityApiTest extends WebTestCase
 
         $this->client->request('POST', '/api/patient_channel_identities', server: $server, content: $body);
         $this->assertSame(409, $this->client->getResponse()->getStatusCode());
+
+        // Дубликат не создал вторую запись — в БД остался ровно 1 контакт.
+        $this->entityManager->clear();
+        $count = $this->entityManager->getRepository(PatientChannelIdentity::class)->count([
+            'patientId' => 42,
+            'channelType' => 'max',
+        ]);
+        $this->assertSame(1, $count);
     }
 }


### PR DESCRIPTION
## Задача
3.39 — Баг BUG-3.1-01: дубликат PatientChannelIdentity → 409

## Что сделано
POST/PUT `PatientChannelIdentity` при нарушении уникальности `(patient_id, channel_type)` теперь возвращает **409** (не 500):
- State-процессор `PatientChannelIdentityProcessor` — маппинг `UniqueConstraintViolationException` → `ConflictHttpException` (409).
- Подключён к операциям `Post`/`Put` через `processor:` в сущности.
- Тест `PatientChannelIdentityApiTest`: дубликат → 409, валидный POST → 201.

## Критерии приёмки
- [x] Дубликат контакта → 409 (не 500)
- [x] Валидный POST → 201 (регресс не сломан)
- [x] Тесты зелёные

## Тесты
`docker compose run --rm -e MAX_API_URL=test -e MAX_BOT_TOKEN=test -e MAX_WEBHOOK_SECRET=test-webhook-secret php vendor/bin/phpunit` → **182 tests, 501 assertions — OK**.

## Как проверить
`POST /api/patient_channel_identities` с дубликатом `(patientId, channelType)` → **409**.

## Аквариум
Секция «Аквариум» статьи 3.39 (в `ibs-docs`).
